### PR TITLE
feat(ignores): add support for user defined ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,14 @@ If you are setting up Sheriff in an already established codebase, follow these s
 
      const sheriffOptions = {
        files: ['./src/**/*'], // 👉 Only the files in the src directory will be linted.
+       ignores: [
+        '**/node_modules/**"',
+        '.git/**',
+        '**/dist/**',
+        '**/build/**',
+        '**/artifacts/**',
+        '**/coverage/**',
+       ],
        react: false,
        next: false,
        lodash: false,

--- a/configs/eslint.config.js
+++ b/configs/eslint.config.js
@@ -799,7 +799,7 @@ const getExportableConfig = (userConfigChoices = {}) => {
 
   exportableConfig.push(prettierConfig);
   exportableConfig.push(prettierOverrides);
-  exportableConfig.push({ ignores });
+  exportableConfig.push({ ignores: userConfigChoices.ignores ?? ignores });
 
   if (userConfigChoices.files) {
     exportableConfig = exportableConfig.map((configSlice) => {


### PR DESCRIPTION
Having the ability to specify a custom tsconfig.json file will be the best option, but in the meanwhile specifying user-defined ignores adds additional functionality while getting rid of the errors found in #27.