### PR TITLE
Add keepalive endpoint

### DIFF
--- a/.changeset/shy-tips-sneeze.md
+++ b/.changeset/shy-tips-sneeze.md
@@ -1,0 +1,5 @@
+---
+'sheriff-webservices': patch
+---
+
+feat(webservice): added keepalive endpoint

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,28 @@
+name: Scheduled API Request
+
+on:
+  schedule:
+    - cron: '*/13 * * * *' # Schedule every 13 minutes
+
+jobs:
+  api-request:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Pnpm Setup
+        uses: pnpm/action-setup@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run API Request Script
+        run: |
+          curl -X GET https://sheriff-webservices.onrender.com/api/keepalive

--- a/apps/sheriff-webservices/src/index.ts
+++ b/apps/sheriff-webservices/src/index.ts
@@ -10,6 +10,9 @@ const port = process.env.PORT || 5001;
 app.use(express.json());
 app.use(cors());
 
+app.get('/api/keepalive', (req: Request, res: Response) => {
+  res.send('OK');
+});
 app.post('/api/get-new-sheriff-config', (req: Request, res: Response) => {
   const newConfig: BarebonesConfigAtom[] = getSheriffConfig(req.body);
   const allRulesConfig: BarebonesConfigAtom[] = getSheriffConfig(


### PR DESCRIPTION
This pull request adds a new endpoint `/api/keepalive` to the existing API. The endpoint returns a response of "OK".