### PR TITLE
Remove license section from README.md, Add ESLint plugins to docs page, Add support for reporting unused disable directives in supported file types

### DIFF
--- a/.changeset/seven-seals-refuse.md
+++ b/.changeset/seven-seals-refuse.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-sheriff': minor
+'docs-website': minor
+---
+
+feat(config): added support for reporting unused directives

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Please use the discussions tab or the issues tab for new rules proposals.
 1. Install the dependencies with pnpm
 1. Do the changes
 
-## 📋 License
-
-[MIT](https://github.com/AndreaPontrandolfo/sheriff/blob/master/LICENSE).
-
 ## 🌤 Changelog
 
 [Releases](https://github.com/AndreaPontrandolfo/sheriff/releases).

--- a/apps/docs-website/docs/eslint-plugins.md
+++ b/apps/docs-website/docs/eslint-plugins.md
@@ -4,7 +4,9 @@ sidebar_position: 7
 
 # 🔌 ESLint plugins
 
+- [@eslint/js](https://www.npmjs.com/package/@eslint/js)
 - [@typescript/eslint](https://github.com/typescript-eslint/typescript-eslint)
+- [@stylistic/eslint-plugin](https://github.com/eslint-stylistic/eslint-stylistic)
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
 - [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react)
 - [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)

--- a/packages/eslint-config-sheriff/src/getExportableConfig.ts
+++ b/packages/eslint-config-sheriff/src/getExportableConfig.ts
@@ -267,6 +267,12 @@ const getBaseConfig = (userConfigChoices: SheriffSettings) => {
         'import/no-default-export': 0,
       },
     },
+    {
+      files: [supportedFileTypes],
+      linterOptions: {
+        reportUnusedDisableDirectives: 'error',
+      },
+    },
   ];
 };
 


### PR DESCRIPTION
This pull request includes the following changes:

- Remove the license section from README.md

- Add some ESLint plugins to the docs page

- Add support for reporting unused disable directives in supported file types