### PR TITLE
Update README with markdown-autodocs

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,16 @@
+name: update README.md with markdown-autodocs
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update README
+        uses: dineshsonachalam/markdown-autodocs@v1.0.7

--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 
 # Sheriff
 
-This repository hosts the sourcecode of the following projects:
+This repository is a monorepo that hosts the sourcecode of the following projects:
 
-- [Sheriff docs website](https://github.com/AndreaPontrandolfo/sheriff/tree/master/apps/docs-website)
-- [eslint-config-sheriff package](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/eslint-config-sheriff)
-- [create-sheriff-config package](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/create-sheriff-config)
-- [@sheriff/types package](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/sheriff-types)
+<!-- MARKDOWN-AUTO-DOCS:START (JSON_TO_HTML_TABLE:src=./readmeMarkdownTable.json) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## 🚀 Getting Started
 

--- a/packages/eslint-config-sheriff/package.json
+++ b/packages/eslint-config-sheriff/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-sheriff",
   "version": "18.0.0",
-  "description": "A comprehensive ESLint configuration.",
+  "description": "A comprehensive and opinionated Typescript-first ESLint configuration.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/readmeMarkdowntable.json
+++ b/readmeMarkdowntable.json
@@ -1,0 +1,26 @@
+[
+  {
+    "Link": "[Sheriff docs website](www.eslint-config-sheriff.dev)",
+    "Source": "[docs-website](https://github.com/AndreaPontrandolfo/sheriff/tree/master/apps/docs-website)",
+    "Description": "Sheriff documentation website",
+    "Version": "[![GitHub release](https://img.shields.io/github/release/AndreaPontrandolfo/your-repository.svg)](https://github.com/AndreaPontrandolfo/sheriff/releases/latest)"
+  },
+  {
+    "Link": "[`eslint-config-sheriff`](https://www.npmjs.com/package/eslint-config-sheriff)",
+    "Source": "[eslint-config-sheriff](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/eslint-config-sheriff)",
+    "Description": "A comprehensive and opinionated Typescript-first ESLint configuration",
+    "Version": "[![npm](https://img.shields.io/npm/v/eslint-config-sheriff.svg)](https://www.npmjs.com/package/eslint-config-sheriff)"
+  },
+  {
+    "Link": "[`create-sheriff-config`](https://www.npmjs.com/package/create-sheriff-config)",
+    "Source": "[create-sheriff-config](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/create-sheriff-config)",
+    "Description": "CLI/starter to bootstrap a Sheriff config",
+    "Version": "[![npm](https://img.shields.io/npm/v/create-sheriff-config.svg)](https://www.npmjs.com/package/create-sheriff-config)"
+  },
+  {
+    "Link": "[`@sheriff/types`](https://www.npmjs.com/package/@sheriff/types)",
+    "Source": "[sheriff-types](https://github.com/AndreaPontrandolfo/sheriff/tree/master/packages/sheriff-types)",
+    "Description": "Sheriff types package",
+    "Version": "[![npm](https://img.shields.io/npm/v/@sheriff/types.svg)](https://www.npmjs.com/package/@sheriff/types)"
+  }
+]


### PR DESCRIPTION
This pull request updates the README file with the markdown-autodocs feature. It adds a table with links, sources, descriptions, and versions for the projects hosted in the repository. Additionally, it improves the description of the `eslint-config-sheriff` package to mention that it is a comprehensive and opinionated Typescript-first ESLint configuration.