### PR TITLE
Fix Bug With Autoinstall

### DIFF
--- a/.changeset/odd-clouds-hug.md
+++ b/.changeset/odd-clouds-hug.md
@@ -1,0 +1,5 @@
+---
+"create-sheriff-config": patch
+---
+
+fix bug with auto install packages to ensure the correct version is installed

--- a/packages/create-sheriff-config/src/utils/autoInstallPackages.ts
+++ b/packages/create-sheriff-config/src/utils/autoInstallPackages.ts
@@ -11,13 +11,8 @@ export const autoInstallPackages = async (
   selectedProject: string | null,
 ): Promise<void> => {
   const packagesLatestVersions = packages.map((packageName) => {
-    if (packageName === 'eslint') {
-      return `eslint@${CURRENT_FROZEN_ESLINT_VERSION}`;
-    }
-
-    // packageName already has a version specified
-    if (packageName.includes('@')) {
-      return packageName
+    if (packageName.includes(`@${CURRENT_FROZEN_ESLINT_VERSION}`)) {
+      return packageName;
     }
 
     return `${packageName}@latest`;

--- a/packages/create-sheriff-config/src/utils/autoInstallPackages.ts
+++ b/packages/create-sheriff-config/src/utils/autoInstallPackages.ts
@@ -15,6 +15,11 @@ export const autoInstallPackages = async (
       return `eslint@${CURRENT_FROZEN_ESLINT_VERSION}`;
     }
 
+    // packageName already has a version specified
+    if (packageName.includes('@')) {
+      return packageName
+    }
+
     return `${packageName}@latest`;
   });
 


### PR DESCRIPTION
Bug:

Running `pnpm dlx create-sheriff-config` yields the following error:

```
 ERROR  Couldn't auto-install the required packages.                                                                                                    10:04:59 PM
      You have to install them manually yourself.
      Please try to run: pnpm add -D eslint@8.57.0 eslint-define-config@latest eslint-config-sheriff@latest eslint-ts-patch@8.57.0@latest eslint@npm:eslint-ts-patch@8.57.0@latest @sherifforg/types@latest
```

The versions are already hard coded here: https://github.com/AndreaPontrandolfo/sheriff/blob/d1971c3cf709b4c97bb3018e552c45ef9e76c0be/packages/create-sheriff-config/src/utils/getRequiredPackages.ts#L20-L21

I wasn't sure how you'd want to resolve this issue, so this PR just adds a generic if statement so skip appending `@latest` if an `@` already exists in the packageName
