### PR TITLE
fix(docs-website): showcase relative path resolving in migration guide page

### DIFF
--- a/apps/docs-website/docs/migration-guide.mdx
+++ b/apps/docs-website/docs/migration-guide.mdx
@@ -32,7 +32,7 @@ import { defineFlatConfig } from "eslint-define-config";
 
 const sheriffOptions = {
   // highlight-next-line
-  files: ["./src/**/*"], // Only the files in the src directory will be linted.
+  files: ["src/**/*"], // Only the files in the src directory will be linted.
   react: false,
   next: false,
   astro: false,
@@ -55,7 +55,7 @@ import { defineFlatConfig } from "eslint-define-config";
 
 const sheriffOptions: SheriffSettings = {
   // highlight-next-line
-  files: ["./src/**/*"], // Only the files in the src directory will be linted.
+  files: ["src/**/*"], // Only the files in the src directory will be linted.
   react: false,
   next: false,
   astro: false,


### PR DESCRIPTION
ESLint `ignore` property follows relative path resolution pattern (Glob).
In the `Migration Guide` page the path `./src/**/*` is passed to `files` config property and that could mislead the users.
More [here](https://eslint.org/docs/latest/use/configure/ignore#glob-pattern-resolution)