### PR TITLE
fix(config): don't run `tsdoc` rules on JS files

### DIFF
--- a/.changeset/slimy-tigers-sin.md
+++ b/.changeset/slimy-tigers-sin.md
@@ -1,0 +1,6 @@
+---
+"eslint-config-sheriff": patch
+---
+
+fix(config): don't run `tsdoc` rules on JS files
+Fixes #362

--- a/packages/eslint-config-sheriff/src/getBaseConfig.ts
+++ b/packages/eslint-config-sheriff/src/getBaseConfig.ts
@@ -58,7 +58,7 @@ export const getBaseConfig = (
       },
     },
     {
-      files: [supportedFileTypes],
+      files: ['**/*.{ts,mts,cts,tsx,mtsx,astro}'],
       plugins: {
         tsdoc,
       },


### PR DESCRIPTION
Don't run `tsdoc` rules on JS files.

## Related Issue

<!--- This project only accepts pull requests related to open issues with the `approved` label -->
<!--- Failure to meet the above basic requirement will see this PR declined immediately -->

<!--- Please link to the issue below 👇 -->

Closes #362

## Other

I'm noticing that some of the patterns are omitting the dot before the extension names:

https://github.com/AndreaPontrandolfo/sheriff/blob/de3364f6134aa362f44f836401f6eecac3ffc09d/packages/sheriff-constants/src/index.ts#L25-L29

So it's `**/*{js,mjs}` instead of `**/*.{js,mjs}`

Is there a reason why?