### PR TITLE
fix: whitelist certain export names

### DIFF
--- a/.changeset/proud-snakes-explain.md
+++ b/.changeset/proud-snakes-explain.md
@@ -1,0 +1,6 @@
+---
+"eslint-config-sheriff": patch
+---
+
+fix: whitelist certain export names
+Fixes #364

--- a/packages/eslint-config-sheriff/src/getExportableConfig.ts
+++ b/packages/eslint-config-sheriff/src/getExportableConfig.ts
@@ -52,7 +52,7 @@ export const getExportableConfig = (
   }
 
   if (userConfigChoices.next) {
-    exportableConfig.push(nextjsConfig);
+    exportableConfig.push(...nextjsConfig);
   }
 
   if (userConfigChoices.lodash) {

--- a/packages/eslint-config-sheriff/src/getReactConfig.ts
+++ b/packages/eslint-config-sheriff/src/getReactConfig.ts
@@ -47,7 +47,10 @@ export const getReactConfig = (
       files: [`**/*{${allJsxExtensions}}`],
       plugins: { 'react-refresh': reactRefresh },
       rules: {
-        'react-refresh/only-export-components': 2,
+        'react-refresh/only-export-components': [
+          2,
+          { allowExportNames: ['loader'] },
+        ],
       },
     },
     {

--- a/packages/eslint-config-sheriff/src/nextjsConfig.ts
+++ b/packages/eslint-config-sheriff/src/nextjsConfig.ts
@@ -1,23 +1,38 @@
 import { fixupPluginRules } from '@eslint/compat';
 import nextjs from '@next/eslint-plugin-next';
 import { supportedFileTypes } from '@sherifforg/constants';
+import type { TSESLint } from '@typescript-eslint/utils';
 
-export const nextjsConfig = {
-  files: [supportedFileTypes],
-  plugins: {
-    '@next/next': fixupPluginRules(nextjs),
+export const nextjsConfig: TSESLint.FlatConfig.ConfigArray = [
+  {
+    files: [supportedFileTypes],
+    plugins: {
+      '@next/next': fixupPluginRules(nextjs),
+    },
+    rules: {
+      ...nextjs.configs.recommended.rules,
+      ...nextjs.configs['core-web-vitals'].rules,
+      'import/no-default-export': 0,
+      'react/function-component-definition': [
+        2,
+        {
+          namedComponents: 'function-declaration',
+          unnamedComponents: 'function-expression',
+        },
+      ],
+      '@next/next/no-html-link-for-pages': 0, // pages router is legacy at this point. We don't need to support this rule anymore.
+    },
   },
-  rules: {
-    ...nextjs.configs.recommended.rules,
-    ...nextjs.configs['core-web-vitals'].rules,
-    'import/no-default-export': 0,
-    'react/function-component-definition': [
-      2,
-      {
-        namedComponents: 'function-declaration',
-        unnamedComponents: 'function-expression',
-      },
+  {
+    files: [
+      '**/page.{js,mjs,cjs,ts,mts,cts,jsx,tsx,mtsx,mjsx}',
+      '**/layout.{js,mjs,cjs,ts,mts,cts,jsx,tsx,mtsx,mjsx}',
     ],
-    '@next/next/no-html-link-for-pages': 0, // pages router is legacy at this point. We don't need to support this rule anymore.
+    rules: {
+      'react-refresh/only-export-components': [
+        2,
+        { allowExportNames: ['metadata', 'generateMetadata'] },
+      ],
+    },
   },
-};
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Make sure to read the [Contributing Guidelines on Pull Requests](https://github.com/AndreaPontrandolfo/sheriff/blob/master/CONTRIBUTING.md#opening-a-new-pull-request) -->

This whitelists certain export names for `react-refresh/only-export-components` that causes issues with certain frameworks like Next.js

## Related Issue

<!--- This project only accepts pull requests related to open issues with the `approved` label -->
<!--- Failure to meet the above basic requirement will see this PR declined immediately -->

<!--- Please link to the issue below 👇 -->

Closes #364
