### PR TITLE
fix(eslint-config-sheriff): Fix Astro TS integration and configure naming-convention for endpoints & components

### DIFF
--- a/packages/eslint-config-sheriff/src/getAstroConfig.ts
+++ b/packages/eslint-config-sheriff/src/getAstroConfig.ts
@@ -1,6 +1,8 @@
 import astro from 'eslint-plugin-astro';
 import tseslint from 'typescript-eslint';
+import { allJsExtensions } from '@sherifforg/constants';
 import type { TSESLint } from '@typescript-eslint/utils';
+import { getTsNamingConventionRule } from './utils/getTsNamingConventionRule';
 
 // eslint-plugin-astro defines the "jsx-a11y" plugin which conflicts with the original plugin
 // The last config object in astro.configs["flat/jsx-a11y-strict"] is the one that defines the "jsx-a11y" plugin
@@ -32,6 +34,7 @@ export const getAstroConfig = (
       files: ['**/*.astro'],
       languageOptions: {
         parserOptions: {
+          parser: tseslint.parser,
           project: customTSConfigPath || true,
           extraFileExtensions: ['.astro'], // this is probably already included in the recommended preset, but we are keeping it for safety.
         },
@@ -55,6 +58,11 @@ export const getAstroConfig = (
           espree: ['.js'],
         },
       },
+      rules: getTsNamingConventionRule({ isTsx: true }),
+    },
+    {
+      files: [`**/src/pages/**/*.{${allJsExtensions}}`],
+      rules: getTsNamingConventionRule({ isTsx: false, isAstroEndpoint: true }),
     },
   );
 };

--- a/packages/eslint-config-sheriff/src/getBaseConfig.ts
+++ b/packages/eslint-config-sheriff/src/getBaseConfig.ts
@@ -99,7 +99,6 @@ export const getBaseConfig = (
     },
     {
       files: [supportedFileTypes],
-      // @ts-expect-error
       rules: {
         ...typescriptHandPickedRules,
         ...getTsNamingConventionRule({ isTsx: false }),

--- a/packages/eslint-config-sheriff/src/getReactConfig.ts
+++ b/packages/eslint-config-sheriff/src/getReactConfig.ts
@@ -41,7 +41,6 @@ export const getReactConfig = (
     },
     {
       files: [`**/*{${allJsxExtensions}}`],
-      // @ts-expect-error
       rules: getTsNamingConventionRule({ isTsx: true }),
     },
     {

--- a/packages/eslint-config-sheriff/src/utils/getTsNamingConventionRule.ts
+++ b/packages/eslint-config-sheriff/src/utils/getTsNamingConventionRule.ts
@@ -1,58 +1,72 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import type { TSESLint } from '@typescript-eslint/utils';
+
 interface GetTsNamingConventionRuleOptions {
   isTsx: boolean;
+  isAstroEndpoint?: boolean;
 }
 
 export const getTsNamingConventionRule = ({
   isTsx,
-}: GetTsNamingConventionRuleOptions) => {
+  isAstroEndpoint,
+}: GetTsNamingConventionRuleOptions): TSESLint.FlatConfig.Rules => {
+  const options: unknown[] = [
+    {
+      selector: 'default',
+      format: ['camelCase', isTsx && 'StrictPascalCase'].filter(Boolean),
+      leadingUnderscore: 'forbid',
+      trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'variable',
+      format: ['camelCase', 'UPPER_CASE'],
+      modifiers: ['const'],
+      types: ['string', 'number'],
+      leadingUnderscore: 'forbid',
+      trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'objectLiteralProperty',
+      format: null,
+      leadingUnderscore: 'allowSingleOrDouble',
+      trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'typeLike',
+      format: ['PascalCase'],
+      leadingUnderscore: 'forbid',
+      trailingUnderscore: 'forbid',
+    },
+    // https://typescript-eslint.io/rules/naming-convention/#enforce-that-boolean-variables-are-prefixed-with-an-allowed-verb
+    {
+      selector: 'variable',
+      types: ['boolean'],
+      format: ['PascalCase'],
+      prefix: ['is', 'are', 'has', 'should', 'can'],
+      leadingUnderscore: 'forbid',
+      trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'variable',
+      modifiers: ['destructured'],
+      format: null,
+    },
+    {
+      selector: 'typeProperty',
+      format: null,
+    },
+  ];
+
+  // Allow Astro endpoints: https://docs.astro.build/en/guides/endpoints/
+  if (isAstroEndpoint) {
+    options.push({
+      selector: 'function',
+      modifiers: ['exported'],
+      format: null,
+      filter: '^(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|CONNECT|TRACE|ALL)$',
+    });
+  }
+
   return {
-    '@typescript-eslint/naming-convention': [
-      2,
-      {
-        selector: 'default',
-        format: ['camelCase', isTsx && 'StrictPascalCase'].filter(Boolean),
-        leadingUnderscore: 'forbid',
-        trailingUnderscore: 'forbid',
-      },
-      {
-        selector: 'variable',
-        format: ['camelCase', 'UPPER_CASE'],
-        modifiers: ['const'],
-        types: ['string', 'number'],
-        leadingUnderscore: 'forbid',
-        trailingUnderscore: 'forbid',
-      },
-      {
-        selector: 'objectLiteralProperty',
-        format: null,
-        leadingUnderscore: 'allowSingleOrDouble',
-        trailingUnderscore: 'forbid',
-      },
-      {
-        selector: 'typeLike',
-        format: ['PascalCase'],
-        leadingUnderscore: 'forbid',
-        trailingUnderscore: 'forbid',
-      },
-      // https://typescript-eslint.io/rules/naming-convention/#enforce-that-boolean-variables-are-prefixed-with-an-allowed-verb
-      {
-        selector: 'variable',
-        types: ['boolean'],
-        format: ['PascalCase'],
-        prefix: ['is', 'are', 'has', 'should', 'can'],
-        leadingUnderscore: 'forbid',
-        trailingUnderscore: 'forbid',
-      },
-      {
-        selector: 'variable',
-        modifiers: ['destructured'],
-        format: null,
-      },
-      {
-        selector: 'typeProperty',
-        format: null,
-      },
-    ],
+    '@typescript-eslint/naming-convention': [2, ...options],
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Make sure to read the [Contributing Guidelines on Pull Requests](https://github.com/AndreaPontrandolfo/sheriff/blob/master/CONTRIBUTING.md#opening-a-new-pull-request) -->

This pull request fixes various issues when using eslint-config-sheriff with Astro.

1. Set `languageOptions.parserOptions.parser` to allow writing TypeScript in Astro frontmatter.
2. Configure `@typescript-eslint/naming-convention` to allow PascalCase in `.astro` files (as components need to be PascalCase in JSX).
3.  Configure `@typescript-eslint/naming-convention` to allow Astro endpoints (see https://docs.astro.build/en/guides/endpoints/)

## Related Issue

<!--- This project only accepts pull requests related to open issues with the `approved` label -->
<!--- Failure to meet the above basic requirement will see this PR declined immediately -->

<!--- Please link to the issue below 👇 -->

Closes #408

## Other

While at it I also took the liberty to return the correct type from `getTsNamingConventionRule` so we can avoid using `@ts-expect-error`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended linting rules to enforce TypeScript naming conventions for Astro files and JavaScript files in the pages directory, with special handling for Astro endpoint function names.

* **Refactor**
  * Improved type safety and structure in naming convention rule configuration.

* **Style**
  * Removed unnecessary TypeScript expect-error comments from configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->