### PR TITLE
fix(config): add support for typed rules in Astro and fix naming convention rule for Astro endpoints

### DIFF
--- a/.changeset/pink-goats-bow.md
+++ b/.changeset/pink-goats-bow.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-sheriff": patch
+---
+
+fix(config): add support for typed rules in Astro and fix naming convention rule for Astro endpoints

--- a/packages/eslint-config-sheriff/src/getAstroConfig.ts
+++ b/packages/eslint-config-sheriff/src/getAstroConfig.ts
@@ -61,6 +61,15 @@ export const getAstroConfig = (
       rules: getTsNamingConventionRule({ isTsx: true }),
     },
     {
+      files: ['**/*.astro/*.ts'], // Virtual files created by eslint-plugin-astro.
+      languageOptions: {
+        parserOptions: {
+          parser: tseslint.parser,
+          project: customTSConfigPath || true,
+        },
+      },
+    },
+    {
       files: [`**/src/pages/**/*.{${allJsExtensions}}`],
       rules: getTsNamingConventionRule({ isTsx: false, isAstroEndpoint: true }),
     },

--- a/packages/eslint-config-sheriff/src/utils/getTsNamingConventionRule.ts
+++ b/packages/eslint-config-sheriff/src/utils/getTsNamingConventionRule.ts
@@ -59,7 +59,8 @@ export const getTsNamingConventionRule = ({
   // Allow Astro endpoints: https://docs.astro.build/en/guides/endpoints/
   if (isAstroEndpoint) {
     options.push({
-      selector: 'function',
+      selector: ['variable', 'function'],
+      types: ['function'],
       modifiers: ['exported'],
       format: null,
       filter: '^(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|CONNECT|TRACE|ALL)$',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Make sure to read the [Contributing Guidelines on Pull Requests](https://github.com/AndreaPontrandolfo/sheriff/blob/master/CONTRIBUTING.md#opening-a-new-pull-request) -->

## Related Issue

<!--- This project only accepts pull requests related to open issues with the `approved` label -->
<!--- Failure to meet the above basic requirement will see this PR declined immediately -->

<!--- Please link to the issue below 👇 -->

Closes #414

## Other

<!--- If there is any other detail you want to add, write it here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ESLint support for virtual TypeScript produced from Astro files so those virtual files are parsed and analyzed.
- Bug Fixes
  - Improved naming-convention enforcement for Astro endpoint handlers to cover both variables and functions, tightening rules for function types.
- Chores
  - Added a changeset entry to publish a patch with these config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->